### PR TITLE
feat(courses): implement initial schema and actions for course manage…

### DIFF
--- a/drizzle/0002_brave_scourge.sql
+++ b/drizzle/0002_brave_scourge.sql
@@ -1,0 +1,45 @@
+CREATE TABLE "course_materials" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"course_id" uuid NOT NULL,
+	"week_id" uuid,
+	"title" varchar(255) NOT NULL,
+	"file_name" varchar(255),
+	"file_path" varchar(500),
+	"file_size" integer,
+	"mime_type" varchar(100),
+	"upload_status" varchar(50) DEFAULT 'pending',
+	"processing_metadata" jsonb,
+	"uploaded_by" uuid NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "course_weeks" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"course_id" uuid NOT NULL,
+	"week_number" integer NOT NULL,
+	"title" varchar(255),
+	"start_date" timestamp,
+	"end_date" timestamp,
+	"is_active" boolean DEFAULT true,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "courses" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"description" text,
+	"language" varchar(50) DEFAULT 'english',
+	"duration_weeks" integer DEFAULT 12,
+	"is_active" boolean DEFAULT true,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "course_materials" ADD CONSTRAINT "course_materials_course_id_courses_id_fk" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_materials" ADD CONSTRAINT "course_materials_week_id_course_weeks_id_fk" FOREIGN KEY ("week_id") REFERENCES "public"."course_weeks"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_materials" ADD CONSTRAINT "course_materials_uploaded_by_users_user_id_fk" FOREIGN KEY ("uploaded_by") REFERENCES "public"."users"("user_id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "course_weeks" ADD CONSTRAINT "course_weeks_course_id_courses_id_fk" FOREIGN KEY ("course_id") REFERENCES "public"."courses"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "courses" ADD CONSTRAINT "courses_user_id_users_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("user_id") ON DELETE cascade ON UPDATE no action;

--- a/drizzle/0002_rls_policies.sql
+++ b/drizzle/0002_rls_policies.sql
@@ -1,0 +1,130 @@
+-- Enable RLS
+ALTER TABLE public.courses ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_weeks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.course_materials ENABLE ROW LEVEL SECURITY;
+
+-- Policies for 'courses' table
+-- Users can see their own courses
+CREATE POLICY "Allow users to see their own courses"
+ON public.courses FOR SELECT
+TO authenticated
+USING (auth.uid() = user_id);
+
+-- Users can create courses for themselves
+CREATE POLICY "Allow users to create their own courses"
+ON public.courses FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = user_id);
+
+-- Users can update their own courses
+CREATE POLICY "Allow users to update their own courses"
+ON public.courses FOR UPDATE
+TO authenticated
+USING (auth.uid() = user_id);
+
+-- Users can delete their own courses
+CREATE POLICY "Allow users to delete their own courses"
+ON public.courses FOR DELETE
+TO authenticated
+USING (auth.uid() = user_id);
+
+
+-- Policies for 'course_weeks' table
+-- Users can see course weeks for courses they have access to
+CREATE POLICY "Allow users to see course weeks for their courses"
+ON public.course_weeks FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM courses
+    WHERE courses.id = course_weeks.course_id
+    AND courses.user_id = auth.uid()
+  )
+);
+
+-- Users can create course weeks for their own courses
+CREATE POLICY "Allow users to create course weeks for their courses"
+ON public.course_weeks FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM courses
+    WHERE courses.id = course_weeks.course_id
+    AND courses.user_id = auth.uid()
+  )
+);
+
+-- Users can update course weeks for their own courses
+CREATE POLICY "Allow users to update course weeks for their courses"
+ON public.course_weeks FOR UPDATE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM courses
+    WHERE courses.id = course_weeks.course_id
+    AND courses.user_id = auth.uid()
+  )
+);
+
+-- Users can delete course weeks for their own courses
+CREATE POLICY "Allow users to delete course weeks for their courses"
+ON public.course_weeks FOR DELETE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM courses
+    WHERE courses.id = course_weeks.course_id
+    AND courses.user_id = auth.uid()
+  )
+);
+
+
+-- Policies for 'course_materials' table
+-- Users can see materials for courses they have access to
+CREATE POLICY "Allow users to see materials for their courses"
+ON public.course_materials FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM courses
+    WHERE courses.id = course_materials.course_id
+    AND courses.user_id = auth.uid()
+  )
+);
+
+-- Users can upload materials for their own courses
+CREATE POLICY "Allow users to upload materials for their courses"
+ON public.course_materials FOR INSERT
+TO authenticated
+WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM courses
+    WHERE courses.id = course_materials.course_id
+    AND courses.user_id = auth.uid()
+  )
+  AND auth.uid() = uploaded_by
+);
+
+-- Users can update materials for their own courses
+CREATE POLICY "Allow users to update materials for their courses"
+ON public.course_materials FOR UPDATE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM courses
+    WHERE courses.id = course_materials.course_id
+    AND courses.user_id = auth.uid()
+  )
+);
+
+-- Users can delete materials for their own courses
+CREATE POLICY "Allow users to delete materials for their courses"
+ON public.course_materials FOR DELETE
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1 FROM courses
+    WHERE courses.id = course_materials.course_id
+    AND courses.user_id = auth.uid()
+  )
+); 

--- a/drizzle/0003_user_rls_policies.sql
+++ b/drizzle/0003_user_rls_policies.sql
@@ -1,0 +1,40 @@
+-- Enable RLS for users and user_plans tables
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.user_plans ENABLE ROW LEVEL SECURITY;
+
+-- Policies for 'users' table
+-- Users can see their own user data
+CREATE POLICY "Allow authenticated users to see their own user data"
+ON public.users FOR SELECT
+TO authenticated
+USING (auth.uid() = user_id);
+
+-- Users can update their own user data
+CREATE POLICY "Allow authenticated users to update their own user data"
+ON public.users FOR UPDATE
+TO authenticated
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+
+-- Policies for 'user_plans' table
+-- Users can see their own plan
+CREATE POLICY "Allow authenticated users to see their own plan"
+ON public.user_plans FOR SELECT
+TO authenticated
+USING (auth.uid() = user_id);
+
+-- Users can create their own plan (e.g., during signup)
+CREATE POLICY "Allow authenticated users to create their own plan"
+ON public.user_plans FOR INSERT
+TO authenticated
+WITH CHECK (auth.uid() = user_id);
+
+-- Users can update their own plan (e.g., cancel or change plan)
+CREATE POLICY "Allow authenticated users to update their own plan"
+ON public.user_plans FOR UPDATE
+TO authenticated
+USING (auth.uid() = user_id)
+WITH CHECK (auth.uid() = user_id);
+
+-- Note: Deleting user plans is restricted to service_role or admin actions. 

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,626 @@
+{
+  "id": "2c9d8c6b-6520-4dc9-89bd-4ab54d84d3a0",
+  "prevId": "854a1016-9770-452d-b2cb-a1ca5c1311fd",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "auth.users": {
+      "name": "users",
+      "schema": "auth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_materials": {
+      "name": "course_materials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_id": {
+          "name": "week_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "file_name": {
+          "name": "file_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "file_size": {
+          "name": "file_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upload_status": {
+          "name": "upload_status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "processing_metadata": {
+          "name": "processing_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_materials_course_id_courses_id_fk": {
+          "name": "course_materials_course_id_courses_id_fk",
+          "tableFrom": "course_materials",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "course_materials_week_id_course_weeks_id_fk": {
+          "name": "course_materials_week_id_course_weeks_id_fk",
+          "tableFrom": "course_materials",
+          "tableTo": "course_weeks",
+          "columnsFrom": [
+            "week_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "course_materials_uploaded_by_users_user_id_fk": {
+          "name": "course_materials_uploaded_by_users_user_id_fk",
+          "tableFrom": "course_materials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.course_weeks": {
+      "name": "course_weeks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "course_id": {
+          "name": "course_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_number": {
+          "name": "week_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "course_weeks_course_id_courses_id_fk": {
+          "name": "course_weeks_course_id_courses_id_fk",
+          "tableFrom": "course_weeks",
+          "tableTo": "courses",
+          "columnsFrom": [
+            "course_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.courses": {
+      "name": "courses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'english'"
+        },
+        "duration_weeks": {
+          "name": "duration_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 12
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "courses_user_id_users_user_id_fk": {
+          "name": "courses_user_id_users_user_id_fk",
+          "tableFrom": "courses",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_plans": {
+      "name": "user_plans",
+      "schema": "",
+      "columns": {
+        "user_plan_id": {
+          "name": "user_plan_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plan_id": {
+          "name": "plan_id",
+          "type": "plan_id",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stripe_subscription_id": {
+          "name": "stripe_subscription_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_price_id": {
+          "name": "stripe_price_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "subscription_status": {
+          "name": "subscription_status",
+          "type": "subscription_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "current_period_end": {
+          "name": "current_period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_plans_user_id_users_user_id_fk": {
+          "name": "user_plans_user_id_users_user_id_fk",
+          "tableFrom": "user_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_plans_stripe_subscription_id_unique": {
+          "name": "user_plans_stripe_subscription_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_subscription_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "user_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'student'"
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "stripe_customer_id": {
+          "name": "stripe_customer_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "timezone": {
+          "name": "timezone",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'UTC'"
+        },
+        "preferences": {
+          "name": "preferences",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "signup_step": {
+          "name": "signup_step",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "users_user_id_users_id_fk": {
+          "name": "users_user_id_users_id_fk",
+          "tableFrom": "users",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        },
+        "users_stripe_customer_id_unique": {
+          "name": "users_stripe_customer_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "stripe_customer_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.plan_id": {
+      "name": "plan_id",
+      "schema": "public",
+      "values": [
+        "free",
+        "monthly",
+        "yearly"
+      ]
+    },
+    "public.subscription_status": {
+      "name": "subscription_status",
+      "schema": "public",
+      "values": [
+        "trialing",
+        "active",
+        "canceled",
+        "incomplete",
+        "incomplete_expired",
+        "past_due",
+        "unpaid",
+        "paused"
+      ]
+    },
+    "public.user_role": {
+      "name": "user_role",
+      "schema": "public",
+      "values": [
+        "student",
+        "instructor",
+        "admin"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1749568393442,
       "tag": "0001_conscious_mandroid",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1749688890357,
+      "tag": "0002_brave_scourge",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -5,6 +5,7 @@ import {
   pgEnum,
   pgSchema,
   pgTable,
+  text,
   timestamp,
   uuid,
   varchar,
@@ -72,6 +73,59 @@ export const userPlans = pgTable("user_plans", {
   startedAt: timestamp("started_at").defaultNow().notNull(),
   currentPeriodEnd: timestamp("current_period_end"),
   isActive: boolean("is_active").default(true).notNull(),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+// Courses table
+export const courses = pgTable("courses", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  userId: uuid("user_id")
+    .notNull()
+    .references(() => users.userId, { onDelete: "cascade" }),
+  name: varchar("name", { length: 255 }).notNull(),
+  description: text("description"),
+  language: varchar("language", { length: 50 }).default("english"),
+  durationWeeks: integer("duration_weeks").default(12),
+  isActive: boolean("is_active").default(true),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+// Course weeks table
+export const courseWeeks = pgTable("course_weeks", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  courseId: uuid("course_id")
+    .notNull()
+    .references(() => courses.id, { onDelete: "cascade" }),
+  weekNumber: integer("week_number").notNull(),
+  title: varchar("title", { length: 255 }),
+  startDate: timestamp("start_date"),
+  endDate: timestamp("end_date"),
+  isActive: boolean("is_active").default(true),
+  createdAt: timestamp("created_at").defaultNow().notNull(),
+  updatedAt: timestamp("updated_at").defaultNow().notNull(),
+});
+
+// Course materials table
+export const courseMaterials = pgTable("course_materials", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  courseId: uuid("course_id")
+    .notNull()
+    .references(() => courses.id, { onDelete: "cascade" }),
+  weekId: uuid("week_id").references(() => courseWeeks.id, {
+    onDelete: "set null",
+  }),
+  title: varchar("title", { length: 255 }).notNull(),
+  fileName: varchar("file_name", { length: 255 }),
+  filePath: varchar("file_path", { length: 500 }),
+  fileSize: integer("file_size"),
+  mimeType: varchar("mime_type", { length: 100 }),
+  uploadStatus: varchar("upload_status", { length: 50 }).default("pending"),
+  processingMetadata: jsonb("processing_metadata"),
+  uploadedBy: uuid("uploaded_by")
+    .notNull()
+    .references(() => users.userId),
   createdAt: timestamp("created_at").defaultNow().notNull(),
   updatedAt: timestamp("updated_at").defaultNow().notNull(),
 });

--- a/src/lib/actions/courses.ts
+++ b/src/lib/actions/courses.ts
@@ -1,0 +1,69 @@
+"use server";
+
+import { db } from "@/db";
+import { courses } from "@/db/schema";
+import { getServerClient } from "@/lib/supabase/server";
+import {
+  type CourseCreationData,
+  CourseCreationSchema,
+} from "@/lib/validations/courses";
+import { and, eq } from "drizzle-orm";
+import { revalidatePath } from "next/cache";
+
+export async function createCourse(formData: CourseCreationData) {
+  const supabase = await getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("You must be logged in to create a course.");
+  }
+
+  const validatedData = CourseCreationSchema.parse(formData);
+
+  const [newCourse] = await db
+    .insert(courses)
+    .values({
+      ...validatedData,
+      userId: user.id,
+    })
+    .returning();
+
+  revalidatePath("/dashboard/materials");
+  return newCourse;
+}
+
+export async function getUserCourses() {
+  const supabase = await getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return [];
+  }
+
+  const userCourses = await db.query.courses.findMany({
+    where: eq(courses.userId, user.id),
+  });
+
+  return userCourses;
+}
+
+export async function getCourseById(courseId: string) {
+  const supabase = await getServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const course = await db.query.courses.findFirst({
+    where: and(eq(courses.id, courseId), eq(courses.userId, user.id)),
+  });
+
+  return course;
+}

--- a/src/lib/validations/courses.ts
+++ b/src/lib/validations/courses.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+
+export const CourseCreationSchema = z.object({
+  name: z.string().min(3, "Course name must be at least 3 characters long"),
+  description: z.string().optional(),
+  language: z.string().optional(),
+  durationWeeks: z.number().int().min(1).optional(),
+});
+
+export type CourseCreationData = z.infer<typeof CourseCreationSchema>;
+
+export const CourseUpdateSchema = CourseCreationSchema.extend({
+  id: z.string().uuid(),
+});
+
+export type CourseUpdateData = z.infer<typeof CourseUpdateSchema>;


### PR DESCRIPTION
…ment

This commit introduces the foundational backend infrastructure for course management as part of Phase 1.2.

Key changes include:
-   **Database Schema**: Adds `courses`, `course_weeks`, and `course_materials` tables to the Drizzle schema.
-   **Migrations**: Includes Drizzle-generated migration files to apply the new schema and adds separate SQL files for RLS policies.
-   **Validations**: Implements Zod schemas for validating course creation and update data.
-   **Server Actions**: Provides server-side functions for creating and retrieving courses.
-   **Security**: Establishes Row Level Security (RLS) policies for the new tables (`courses`, `course_weeks`, `course_materials`) and extends RLS to the existing `users` and `user_plans` tables to ensure data isolation.