### PR TITLE
fix: prevent database query errors in notes page when weekId is empty

### DIFF
--- a/src/lib/actions/notes.ts
+++ b/src/lib/actions/notes.ts
@@ -64,6 +64,10 @@ export async function getNotesData(courseId: string, weekId: string) {
 export async function getGoldenNotes(courseId: string, weekId: string) {
 	return await withErrorHandling(
 		async () => {
+			if (!weekId || weekId.trim() === "") {
+				return [];
+			}
+
 			const notes = await db
 				.select({
 					id: goldenNotes.id,
@@ -94,6 +98,10 @@ export async function getGoldenNotes(courseId: string, weekId: string) {
 export async function getSummaries(courseId: string, weekId: string) {
 	return await withErrorHandling(
 		async () => {
+			if (!weekId || weekId.trim() === "") {
+				return [];
+			}
+
 			const summaryData = await db
 				.select({
 					id: summaries.id,


### PR DESCRIPTION
## Summary
Fixed database query errors in notes page by adding early return checks when weekId is empty.

## Changes
- Add validation in getSummaries() and getGoldenNotes() functions
- Return empty arrays when weekId is empty instead of querying database