### PR TITLE
URGENT: Fix middleware RLS blocking onboarding completion

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,8 +1,9 @@
-import { getServerClient } from "@/lib/supabase/server";
+import { getAdminClient, getServerClient } from "@/lib/supabase/server";
 import { type NextRequest, NextResponse } from "next/server";
 
 async function isOnboardingComplete(userId: string): Promise<boolean> {
-	const supabase = await getServerClient();
+	// Use admin client to bypass RLS policies for middleware checks
+	const supabase = getAdminClient();
 	const { data: user, error } = await supabase
 		.from("users")
 		.select("onboarding_completed, onboarding_skipped")


### PR DESCRIPTION
## Critical Fix

Users are stuck in onboarding loop despite having completed/skipped onboarding in database.

## Root Cause
Middleware was using regular Supabase client which respects RLS policies. Since the users table has RLS enabled, the middleware couldn't read onboarding status and always returned false for `isOnboardingComplete()`.

## Solution
- Use admin client in middleware for system-level checks
- Bypasses RLS for legitimate middleware operations
- Maintains security for user-facing operations

## Impact
- Fixes users unable to exit onboarding flow
- Resolves infinite redirect loops
- Restores normal dashboard access