### PR TITLE
fix: return materialId in process-and-embed-individual-material task output

### DIFF
--- a/src/trigger/process-and-embed-individual-material.ts
+++ b/src/trigger/process-and-embed-individual-material.ts
@@ -19,6 +19,10 @@ const ProcessAndEmbedIndividualPayload = z.object({
 
 const ProcessAndEmbedIndividualOutput = z.object({
 	success: z.boolean(),
+	materialId: z.string(),
+	chunksCreated: z.number().optional(),
+	textLength: z.number().optional(),
+	contentType: z.string().optional(),
 });
 
 type ProcessAndEmbedIndividualPayloadType = z.infer<
@@ -151,6 +155,10 @@ export const processAndEmbedIndividualMaterial = schemaTask({
 
 			return {
 				success: true,
+				materialId,
+				chunksCreated: chunks.length,
+				textLength: extractedText.length,
+				contentType,
 			};
 		} catch (error) {
 			const errorMessage =


### PR DESCRIPTION
## Summary
- Fixes database query parameter binding error in ingest-course-materials job
- Task now returns materialId along with other metadata in output schema

## Root Cause
The process-and-embed-individual-material task was only returning `{ success: true }` but the ingest-course-materials job expected a `materialId` field. This caused undefined values to be passed to the database query, resulting in parameter binding failure.

## Changes
- Updated return statement to include materialId, chunksCreated, textLength, and contentType
- Updated output schema validation to match expected return type