### PR TITLE
fix(pdf-strategy): convert Buffer to Uint8Array for unpdf compatibility

### DIFF
--- a/src/lib/processing/strategies/pdf-strategy.ts
+++ b/src/lib/processing/strategies/pdf-strategy.ts
@@ -18,7 +18,13 @@ const extractWithUnpdf = async (
 	try {
 		// Dynamic import to avoid evaluating browser-dependent code at build time
 		const { extractText } = await import("unpdf");
-		const result = await extractText(buffer);
+		// unpdf expects Uint8Array rather than Node Buffer
+		const uint8 = new Uint8Array(
+			buffer.buffer,
+			buffer.byteOffset,
+			buffer.byteLength
+		);
+		const result = await extractText(uint8);
 		// Handle both string and array responses from unpdf
 		const text = Array.isArray(result)
 			? result.join(" ")


### PR DESCRIPTION
## Summary
- Fixes Buffer to Uint8Array conversion in PDF processing strategy
- Ensures proper compatibility with unpdf library expectations
- Resolves potential processing errors when extracting text from PDF files

## Changes
- Modified `extractWithUnpdf` function to convert Node.js Buffer to Uint8Array
- Added proper buffer conversion using byteOffset and byteLength properties
- Maintains existing error handling and text processing logic