### PR TITLE
[Security] Add CSP frame-ancestors header

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,10 @@ const nextConfig: NextConfig = {
 						key: "X-XSS-Protection",
 						value: "1; mode=block",
 					},
+					{
+						key: "Content-Security-Policy",
+						value: "frame-ancestors 'self' https://godwn.dev",
+					},
 				],
 			},
 		];


### PR DESCRIPTION
## Summary
Adds Content-Security-Policy header to allow framing from godwn.dev domain for secure iframe embedding.

## What Changed
- Added Content-Security-Policy header in next.config.ts
- Configured frame-ancestors directive to allow 'self' and https://godwn.dev
- Maintains existing security headers structure

## Testing
- Verify Next.js builds successfully
- Test iframe embedding from godwn.dev domain
- Confirm other domains are still restricted

## Notes
- This allows secure iframe embedding while maintaining security restrictions
- Only affects frame-ancestors policy, other CSP directives remain unchanged