### PR TITLE
[Fix] Update CSP frame-ancestors to allow all origins

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,10 +16,6 @@ const nextConfig: NextConfig = {
 				source: "/(.*)",
 				headers: [
 					{
-						key: "X-Frame-Options",
-						value: "DENY",
-					},
-					{
 						key: "X-Content-Type-Options",
 						value: "nosniff",
 					},
@@ -33,7 +29,7 @@ const nextConfig: NextConfig = {
 					},
 					{
 						key: "Content-Security-Policy",
-						value: "frame-ancestors 'self' https://godwn.dev",
+						value: "frame-ancestors *",
 					},
 				],
 			},


### PR DESCRIPTION
## Summary
Removes X-Frame-Options header and updates Content Security Policy frame-ancestors directive to allow all origins.

## What Changed
- Removed X-Frame-Options: DENY header (conflicts with CSP)
- Updated CSP frame-ancestors from 'self' https://godwn.dev to *
- Allows embedding application in any iframe context

## Testing
- Verify application can be embedded in external iframes
- Check browser console for CSP violations (should be none)

## Notes
This change relaxes frame embedding restrictions - consider security implications for production use.